### PR TITLE
Services refactoring

### DIFF
--- a/controllers/azure.go
+++ b/controllers/azure.go
@@ -43,7 +43,7 @@ func (c *AzureController) RegisterRoutes(router *gin.RouterGroup) {
 // @Router /v1/azure/projects/list [get]
 func (AzureController) getProjectsList(ctx *gin.Context) {
 	projects, _, err := client.Projects.Projects(
-		&services.ProjectsParams{ApiVersion: "5.1"},
+		&services.ProjectsParams{},
 	)
 	if err != nil {
 		httputil.NewInternalAzureError(ctx)
@@ -71,8 +71,7 @@ func (AzureController) getProjectTeams(ctx *gin.Context) {
 	}
 
 	projectTeams, _, err := client.Projects.ProjectTeams(
-		projectId,
-		&services.ProjectsParams{ApiVersion: "5.0"},
+		&services.ProjectTeamsParams{ProjectId: projectId},
 	)
 
 	if err != nil {
@@ -103,9 +102,8 @@ func (AzureController) getTeamMembers(ctx *gin.Context) {
 	}
 
 	teamMembers, _, err := client.Teams.TeamMembers(
-		projectId,
-		teamId,
-		&services.TeamsParams{ApiVersion: "5.1"},
+		&services.TeamMembersParams{ProjectId: projectId,
+			TeamId: teamId},
 	)
 
 	if err != nil {
@@ -136,9 +134,8 @@ func (AzureController) getTeamIterations(ctx *gin.Context) {
 	}
 
 	teamIterations, _, err := client.Teams.TeamIterations(
-		projectId,
-		teamId,
-		&services.TeamsParams{ApiVersion: "5.1"},
+		&services.TeamIterationsParams{ProjectId: projectId,
+			TeamId: teamId},
 	)
 
 	if err != nil {
@@ -172,11 +169,10 @@ func (AzureController) getMemberWorkItems(ctx *gin.Context) {
 	}
 
 	workItems, err := client.WorkItems.MemberWorkItems(
-		projectId,
-		teamId,
-		iteration,
-		userEmail,
-		&services.WorkItemsParams{ApiVersion: "5.1"},
+		&services.MemberWorkItemsParams{ProjectId: projectId,
+			TeamId:    teamId,
+			Iteration: iteration,
+			UserEmail: userEmail},
 	)
 
 	if err != nil {

--- a/services/azureClient.go
+++ b/services/azureClient.go
@@ -6,8 +6,13 @@ import (
 )
 
 const (
-	azureAPI = "https://dev.azure.com/"
+	azureAPI   = "https://dev.azure.com/"
+	apiVersion = "5.1"
 )
+
+type clientParams struct {
+	ApiVersion string `url:"api-version,omitempty"`
+}
 
 type AzureClient struct {
 	sling     *sling.Sling
@@ -18,7 +23,12 @@ type AzureClient struct {
 
 func NewAzureClient(token string, organization string) *AzureClient {
 	httpClient := &http.Client{}
-	base := sling.New().Client(httpClient).Base(azureAPI).SetBasicAuth("", token)
+	base := sling.
+		New().
+		Client(httpClient).
+		Base(azureAPI).
+		SetBasicAuth("", token).
+		QueryStruct(clientParams{ApiVersion: apiVersion})
 
 	return &AzureClient{
 		sling:     base,

--- a/services/projectsService.go
+++ b/services/projectsService.go
@@ -18,23 +18,25 @@ func newProjectsService(sling *sling.Sling, organization string) *ProjectsServic
 	}
 }
 
-type ProjectsParams struct {
-	ApiVersion string `url:"api-version,omitempty"`
-}
+type ProjectsParams struct{}
 
 // Api reference - https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-5.1
 func (s *ProjectsService) Projects(params *ProjectsParams) (*azure.ProjectsList, *http.Response, error) {
 	projects := new(azure.ProjectsList)
 	apiError := new(httputil.APIError)
-	resp, err := s.sling.New().Get("").QueryStruct(params).Receive(projects, apiError)
+	resp, err := s.sling.New().Get("").Receive(projects, apiError)
 	return projects, resp, httputil.RelevantError(err, apiError)
 }
 
+type ProjectTeamsParams struct {
+	ProjectId string
+}
+
 // Api reference - https://docs.microsoft.com/en-us/rest/api/azure/devops/core/teams/get%20teams?view=azure-devops-rest-5.1
-func (s *ProjectsService) ProjectTeams(projectId string, params *ProjectsParams) (*azure.TeamsList, *http.Response, error) {
+func (s *ProjectsService) ProjectTeams(params *ProjectTeamsParams) (*azure.TeamsList, *http.Response, error) {
 	projectTeams := new(azure.TeamsList)
 	apiError := new(httputil.APIError)
-	path := fmt.Sprintf("%s/teams", projectId)
-	resp, err := s.sling.New().Get(path).QueryStruct(params).Receive(projectTeams, apiError)
+	path := fmt.Sprintf("%s/teams", params.ProjectId)
+	resp, err := s.sling.New().Get(path).Receive(projectTeams, apiError)
 	return projectTeams, resp, httputil.RelevantError(err, apiError)
 }

--- a/services/teamsService.go
+++ b/services/teamsService.go
@@ -12,30 +12,36 @@ type TeamsService struct {
 	sling *sling.Sling
 }
 
-type TeamsParams struct {
-	ApiVersion string `url:"api-version,omitempty"`
-}
-
 func newTeamsService(sling *sling.Sling, organization string) *TeamsService {
 	return &TeamsService{
 		sling: sling.Path(fmt.Sprintf("%s/", organization)),
 	}
 }
 
+type TeamMembersParams struct {
+	ProjectId string
+	TeamId    string
+}
+
 // Api reference - https://docs.microsoft.com/en-us/rest/api/azure/devops/core/teams/get%20team%20members%20with%20extended%20properties?view=azure-devops-rest-5.1
-func (s *TeamsService) TeamMembers(projectId, teamId string, params *TeamsParams) (*azure.MembersList, *http.Response, error) {
+func (s *TeamsService) TeamMembers(params *TeamMembersParams) (*azure.MembersList, *http.Response, error) {
 	members := new(azure.MembersList)
 	apiError := new(httputil.APIError)
-	path := fmt.Sprintf("_apis/projects/%s/teams/%s/members", projectId, teamId)
-	resp, err := s.sling.New().Get(path).QueryStruct(params).Receive(members, apiError)
+	path := fmt.Sprintf("_apis/projects/%s/teams/%s/members", params.ProjectId, params.TeamId)
+	resp, err := s.sling.New().Get(path).Receive(members, apiError)
 	return members, resp, httputil.RelevantError(err, apiError)
 }
 
+type TeamIterationsParams struct {
+	ProjectId string
+	TeamId    string
+}
+
 // Api reference - https://docs.microsoft.com/en-us/rest/api/azure/devops/work/iterations/list?view=azure-devops-rest-5.1
-func (s *TeamsService) TeamIterations(projectId, teamId string, params *TeamsParams) (*azure.IterationsList, *http.Response, error) {
+func (s *TeamsService) TeamIterations(params *TeamIterationsParams) (*azure.IterationsList, *http.Response, error) {
 	iterations := new(azure.IterationsList)
 	apiError := new(httputil.APIError)
-	path := fmt.Sprintf("%s/%s//_apis/work/teamsettings/iterations", projectId, teamId)
-	resp, err := s.sling.New().Get(path).QueryStruct(params).Receive(iterations, apiError)
+	path := fmt.Sprintf("%s/%s//_apis/work/teamsettings/iterations", params.ProjectId, params.TeamId)
+	resp, err := s.sling.New().Get(path).Receive(iterations, apiError)
 	return iterations, resp, httputil.RelevantError(err, apiError)
 }


### PR DESCRIPTION
Moved api version to AzureClient,
removed QueryStruct() calls from sling chains in the all of the services,
also created necessary params structs.